### PR TITLE
[FIX] Removing Slack notification URL verification

### DIFF
--- a/app/Http/Requests/StoreNotificationRequest.php
+++ b/app/Http/Requests/StoreNotificationRequest.php
@@ -17,8 +17,7 @@ class StoreNotificationRequest extends Request
         return [
             'name'         => 'required|max:255',
             'channel'      => 'required|max:255|channel',
-            'webhook'      => 'required|regex:/^https:\/\/hooks.slack.com' .
-                              '\/services\/[a-z0-9]+\/[a-z0-9]+\/[a-z0-9]+$/i',
+            'webhook'      => 'required|url',
             'failure_only' => 'boolean',
             'project_id'   => 'required|integer|exists:projects,id',
         ];


### PR DESCRIPTION
Currently the request checks the Slack URL format but other services like Rocket.chat as compatible with Slack webhooks.


- [x] I have read and understood the [contributing guidelines](https://github.com/REBElinBLUE/deployer/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [ ] Do the TravisCI tests pass?
- [ ] Does the StyleCI test pass?


---

### Description of change

We are currently migrating from Slack to Rocket.chat in order to host our data. Rocket.chat webhooks are 100% compatible with Slach webhooks but cannot be used on Deployer as the request is checking the webhook URL format that must match Slack format. 
Removing this check and replacing it with a simple URL check should allow anyone to use webhooks for Rocket chat too.
